### PR TITLE
Typo (large should be huge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ has_attached_file :image, {
     %s(small@2x)  => "960x",
     %s(medium@2x) => "1536x",
     %s(large@2x)  => "2000x",
-    %s(large@2x)  => "3200x"
+    %s(huge@2x)  => "3200x"
   }
 ```
 


### PR DESCRIPTION
```
%s(large@2x)  => "3200x"
```

should be

```
%s(huge@2x)  => "3200x"
```

in the README, if I extrapolate the other values.
